### PR TITLE
Sequence operators (#11)

### DIFF
--- a/Simulation/bloch_symmetric_splitting.m
+++ b/Simulation/bloch_symmetric_splitting.m
@@ -15,9 +15,9 @@ function [Mfinal, Msample] = bloch_symmetric_splitting(dt, B1, grad, x, T1, T2, 
 % * grad (3,T): Gradient field waveforms along x-, y-, and z-axes
 %
 % Spatially-varying inputs
-% NOTE: [X] denotes up to 4 dimensions, enabling
-% the manipulation of collections that have up to 4 independent variables,
-% such as full 3D plus varying degrees of frequency shift.
+% NOTE: [X] denotes up to 4 dimensions, enabling the manipulation of
+% collections that have up to 4 independent variables, such as full 3D plus
+% varying degrees of frequency shift.
 % * x (3,1,[X]): Spatial coordinates for each point
 % * T1 (1,1,[X]): Longitudinal relaxation time for each point
 % * T2 (1,1,[X]): Transverse relaxation time for each point
@@ -56,7 +56,7 @@ function [Mfinal, Msample] = bloch_symmetric_splitting(dt, B1, grad, x, T1, T2, 
 % ~ Output ~
 % * Mfinal (3,1,[X]): The last simulation state for each point in space
 % * Msample (3,S,[X]): Intermediate simulation states for each point in
-% space. Empty unless sampleComb or samplePeriod are defined.
+% space. Empty unless samplePeriod is defined or any(sampleComb).
 %
 %% 2023-05-15 Samuel Adams-Tew
 arguments
@@ -210,7 +210,7 @@ for iter = 1:length(B1)
     end
 end
 
-% Return the final simulatin state
+% Return the final simulation state
 Mfinal = Mloop;
 
 end

--- a/Simulation/event_operator.m
+++ b/Simulation/event_operator.m
@@ -1,0 +1,166 @@
+function [A, b] = event_operator(dt, B1, grad, options)
+%% [A, b] = event_operator(dt, B1, grad, options)
+% Computes the operator for an event step in MR sequence simulation. If the
+% event includes sampling, an operator is created for each sample time
+% point as well as the final simulation state.
+%
+% ~ Input ~
+% * dt (scalar) [s]: Time step between each element of the input waveforms.
+% * B1 (1,T) [T]: Complex valued B1 field values for each time point.
+% * grad (3,T) [T/m]: Gradient field waveforms along x-, y-, and z-axes.
+%
+% ~ Options ~
+% * gamma (scalar) [rad/(s*T)]: Gyromagnetic ratio for on-resonance
+% excitation. Default is that of water protons, 267.5153151e6.
+% * B0 (scalar) [T]: Main magnetic field strength. Default is 3.
+% * sampleComb (1,T) (logical): Array that indicates which time points
+% should be sampled. If any(sampleComb), [A, b] are cell arrays with
+% operators that give the magnetization state at each sample time as well
+% as the final state. Otherwise, [A, b] are tensor fields for a single
+% operation that applies the full event to get the final state.
+%
+% Spatially-varying optional inputs. 
+% NOTE: [X] denotes up to 4 dimensions, enabling the manipulation of
+% collections that have up to 4 independent variables, such as full 3D plus
+% varying degrees of frequency shift.
+% * x (3,1,[X]) [m]: Spatial coordinates for each point
+% * T1 (1,1,[X]) [s]: Longitudinal relaxation time for each point
+% * T2 (1,1,[X]) [s]: Transverse relaxation time for each point
+% * B0map (1,1,[X]): Spatially varying main field inhomogeneities, applied
+% as an additive factor. Default is 0 for all points.
+% * B1map (1,1,[X]) [scale factor]: Spatially varying B1 field, applied by
+% multiplication with the B1 field at each time. Default is 1 for all
+% points.
+% * delta (1,1,[X]) [ppm]: Frequency offset / chemical shift. Default is 0
+% for all points.
+%
+% ~ Output ~
+% * A (3,3,[X]): Tensor field containing the multiplication part of a
+% linear operation applying the excitation, precession, and relaxation for
+% the given sequence waveforms and object properties.
+% * b (3,1,[X]): Vector field containing the bias for relaxation effects
+% during the event.
+%
+%% 2023-06-12 Samuel Adams-Tew
+arguments
+    dt (1,1) {mustBeNumeric, mustBeReal, mustBePositive}
+    B1 (1,:) {mustBeNumeric}
+    grad (3,:) {mustBeNumeric, mustBeReal}
+    options.T1 (1,1,:,:,:,:) {mustBeNumeric, mustBeReal} = Inf;
+    options.T2 (1,1,:,:,:,:) {mustBeNumeric, mustBeReal} = Inf;
+    options.pos (3,1,:,:,:,:) {mustBeNumeric, mustBeReal} = [0; 0; 1];
+    options.B1map (1,1,:,:,:,:) {mustBeNumeric, mustBeReal} = 1;
+    options.B0map (1,1,:,:,:,:) {mustBeNumeric, mustBeReal} = 0;
+    options.delta (1,1,:,:,:,:) {mustBeNumeric, mustBeReal} = 0;
+    options.sampleComb (1,:) logical = [];
+    options.Meq (1,1,:,:,:,:) {mustBeNumeric, mustBeReal} = 1;
+    options.B0 (1,1) {mustBeNumeric, mustBeReal} = 3;
+    options.gamma (1,1) {mustBeNumeric, mustBeReal} = 267.5153151e6;
+end
+%% Parse inputs
+% Check that the input waveforms have the same number of samples
+if length(B1) ~= size(grad, 2) % Validate duration
+    error('Temporally varying inputs (B1, grad) must have same number of columns.')
+end
+% Check whether this is a sampled event and validate sampleComb
+if any(options.sampleComb)
+    if length(B1) ~= length(options.sampleComb)
+        error('Temporally varying inputs (B1, sampleComb) must have same number of columns.')
+    end
+    sampleIter = find(options.sampleComb);
+else
+    sampleIter = [];
+end
+% Read in spatial variables
+x = options.pos; T1 = options.T1; T2 = options.T2;
+% Extent of spatial / independent variables
+fieldSize = size(x, 3:6);
+% Check that spatially varying inputs have same number of entries
+if any(fieldSize ~= [size(T1, 3:6); size(T2, 3:6)], "all")
+    error('Spatially varying inputs (pos, T1, T2) must have same number of independent variables.')
+end
+% Check that the frequency offset is the same size as spatial inputs
+delta = options.delta*1e-6; % convert 1 ppm = 1e-6
+if length(delta) == 1
+    delta = delta.*ones(size(T1));
+elseif any(fieldSize ~= size(delta, 3:6))
+    error('delta must have same number of independent variables as pos.')
+end
+% Check that B0 inhomogeneity is the same size as spatial inputs
+B0map = options.B0map;
+if length(B0map) == 1
+    B0map = B0map.*ones(size(T1)); % Apply same weight to all points
+elseif any(fieldSize ~= size(B0map, 3:6)) % Validate number of points
+    error('dB0 must have same number of independent variables as pos.')
+end
+% Check that B1 inhomogeneity is same size as spatial inputs
+B1map = options.B1map;
+if length(B1map) == 1
+    B1map = B1map.*ones(size(T1)); % Apply same weight to all points
+elseif any(fieldSize ~= size(B1map, 3:6)) % Validate number of points
+    error('dB1 must have same number of independent variables as pos.')
+end
+% Check that equilibrium magnetization is same size as spatial inputs
+Meq = options.Meq;
+if length(Meq) == 1
+    Meq = Meq.*ones(size(T1)); % Apply same weight to all points
+elseif any(fieldSize ~= size(Meq, 3:6)) % Validate number of points
+    error('delta must have same number of independent variables as pos.')
+end
+% Constants
+gamma = options.gamma;
+B0 = options.B0;
+
+clear options
+
+%% Initialize variables 
+
+if ~isempty(sampleIter)
+    % If this is sampled, return an operator that gives the state at each
+    % sampled time and an operator for the final state as a cell array.
+    A = cell(1, length(sampleIter) + 1);
+    b = cell(1, length(sampleIter) + 1);
+end
+
+% Initialize with the identity element for the respective operations
+Aloop = eye(3).*ones(size(T1)); % Matrix multiplication
+bLoop = [0; 0; 0].*ones(size(T1)); % Vector addition
+
+%% Iterate over event steps, compute operator field
+
+nIter = length(B1);
+saveNum = 1; % Index into sampleIter, (saveNum - 1) is how many values have been saved
+% Loop over each step of the event
+for iter = 1:nIter
+    % Compute axis of rotation
+    axX = (1 + delta).*real(B1(iter)*B1map);
+    axY = (1 + delta).*imag(B1(iter)*B1map);
+    axZ = ( delta*B0 + (1 + delta).*(B0map + sum(grad(:, iter).*x)) );
+    % Compute half of rotation angle; note clockwise rotation
+    ang = -gamma*sqrt(axX.^2 + axY.^2 + axZ.^2) * dt/2;
+
+    % Compute rotation matrix
+    Rot = axis_angle_rotation_matrix([axX; axY; axZ], ang);
+    % Compute relaxation terms
+    [Rel, Rec] = relaxation(dt, T1, T2, Meq);
+
+    % Compute matrix and offset components of operator
+    Aloop = pagemtimes(Rot, Rel.*pagemtimes(Rot, Aloop));
+    bLoop = pagemtimes(Rot, Rel.*pagemtimes(Rot, bLoop)) + Rec;
+
+    % If this is a sampled event, save operator for sampled states
+    if ~isempty(sampleIter) && iter == sampleIter(saveNum)
+        A{saveNum} = Aloop; b{saveNum} = bLoop; % Store operators in output
+        saveNum = min(saveNum + 1, length(sampleIter)); % Update save count
+    end
+end
+
+if isempty(sampleIter)
+    % Return operator for final state
+    A = Aloop; b = bLoop;
+else
+    % Save operator for final state to output arrays
+    A{end} = Aloop; b{end} = bLoop;
+end
+
+end

--- a/Testing/OperatorTest.m
+++ b/Testing/OperatorTest.m
@@ -1,0 +1,258 @@
+classdef OperatorTest < matlab.unittest.TestCase
+    %% Unit tests for comparing
+    % Compare results of applying operators created by event_operator to
+    % the output given by bloch_symmetric_splitting
+    %
+    % 2023-06-12 Samuel Adams-Tew
+
+    methods (TestClassSetup)
+        % Shared setup for the entire test class
+        function setup(testCase)
+            addpath(genpath('./'))
+        end
+    end
+
+    methods (TestMethodSetup)
+        % Setup for each test
+    end
+
+    methods (Test)
+        % Test methods
+        function sliceSelectTest(testCase)
+            %% Setup object and sequence for slice-selective excitation test
+            [dt, ~, B1, grad, pos, delta, T1, T2, dB0, B1map, M0] = sssetup();
+            T1 = 600*T1; T2 = 100*T2;
+
+            % Symmetric splitting simulation
+            [Msim, ~] = bloch_symmetric_splitting(dt*1e-3, B1*1e-3, grad*1e-3, pos*1e-3, T1*1e-3, T2*1e-3, delta=delta, B0map=dB0, B1map=B1map, Meq=M0);
+
+            figure();
+            [meas, Mz] = split_magnetization(Msim);
+            plot_magnetization(pos(3,:),meas,Mz);
+            sgtitle('Slice select test simulation'); xlabel('Z-position (mm)')
+
+            % Compute and apply operator
+            [A, b] = event_operator(dt*1e-3, B1*1e-3, grad*1e-3, 'pos', pos*1e-3, 'T1', T1*1e-3, 'T2', T2*1e-3, 'B0map', dB0, 'delta', delta, 'B1map', B1map);
+            Mop = pagemtimes(A, [zeros(size(T1)); zeros(size(T1)); M0]) + b;
+
+            % Compare
+            testCase.verifyLessThan(mean( (Msim(:) - Mop(:)).^2 ), 1e-6);
+        end
+
+        function ssDeltaTest(testCase)
+            %% Setup object and sequence for slice-selective excitation test
+            [dt, ~, B1, grad, pos, delta, T1, T2, dB0, B1map, M0] = sssetup();
+            T1 = 600*T1; T2 = 100*T2;
+            delta = reshape(linspace(-50, 50, length(delta)), size(delta));
+
+            % Symmetric splitting simulation
+            [Msim, ~] = bloch_symmetric_splitting(dt*1e-3, B1*1e-3, grad*1e-3, pos*1e-3, T1*1e-3, T2*1e-3, delta=delta, B0map=dB0, B1map=B1map, Meq=M0);
+
+            figure();
+            [meas, Mz] = split_magnetization(Msim);
+            plot_magnetization(pos(3,:),meas,Mz);
+            sgtitle('SS delta test simulation'); xlabel('Z-position (mm)')
+
+            % Compute and apply operator
+            [A, b] = event_operator(dt*1e-3, B1*1e-3, grad*1e-3, 'pos', pos*1e-3, 'T1', T1*1e-3, 'T2', T2*1e-3, 'B0map', dB0, 'delta', delta, 'B1map', B1map);
+            Mop = pagemtimes(A, [zeros(size(T1)); zeros(size(T1)); M0]) + b;
+
+            % Compare
+            testCase.verifyLessThan(mean( (Msim(:) - Mop(:)).^2 ), 1e-6);
+        end
+
+        function ssT1Test(testCase)
+            %% Setup object and sequence for slice-selective excitation test
+            [dt, ~, B1, grad, pos, delta, T1, T2, dB0, B1map, M0] = sssetup();
+            T1 = reshape(linspace(1, 10, length(T1)), size(T1)); T2 = 100*T2;
+
+            % Symmetric splitting simulation
+            [Msim, ~] = bloch_symmetric_splitting(dt*1e-3, B1*1e-3, grad*1e-3, pos*1e-3, T1*1e-3, T2*1e-3, delta=delta, B0map=dB0, B1map=B1map, Meq=M0);
+
+            figure();
+            [meas, Mz] = split_magnetization(Msim);
+            plot_magnetization(pos(3,:),meas,Mz);
+            sgtitle('SS T1 test simulation'); xlabel('Z-position (mm)')
+
+            % Compute and apply operator
+            [A, b] = event_operator(dt*1e-3, B1*1e-3, grad*1e-3, 'pos', pos*1e-3, 'T1', T1*1e-3, 'T2', T2*1e-3, 'B0map', dB0, 'delta', delta, 'B1map', B1map);
+            Mop = pagemtimes(A, [zeros(size(T1)); zeros(size(T1)); M0]) + b;
+
+            % Compare
+            testCase.verifyLessThan(mean( (Msim(:) - Mop(:)).^2 ), 1e-6);
+        end
+
+        function ssT2Test(testCase)
+            %% Setup object and sequence for slice-selective excitation test
+            [dt, ~, B1, grad, pos, delta, T1, T2, dB0, B1map, M0] = sssetup();
+            T1 = 600*T1; T2 = reshape(linspace(1, 10, length(T2)), size(T2));
+
+            % Symmetric splitting simulation
+            [Msim, ~] = bloch_symmetric_splitting(dt*1e-3, B1*1e-3, grad*1e-3, pos*1e-3, T1*1e-3, T2*1e-3, delta=delta, B0map=dB0, B1map=B1map, Meq=M0);
+
+            figure();
+            [meas, Mz] = split_magnetization(Msim);
+            plot_magnetization(pos(3,:),meas,Mz);
+            sgtitle('SS T2 test simulation'); xlabel('Z-position (mm)')
+
+            % Compute and apply operator
+            [A, b] = event_operator(dt*1e-3, B1*1e-3, grad*1e-3, 'pos', pos*1e-3, 'T1', T1*1e-3, 'T2', T2*1e-3, 'B0map', dB0, 'delta', delta, 'B1map', B1map);
+            Mop = pagemtimes(A, [zeros(size(T1)); zeros(size(T1)); M0]) + b;
+
+            % Compare
+            testCase.verifyLessThan(mean( (Msim(:) - Mop(:)).^2 ), 1e-6);
+        end
+
+        function ssB0mapTest(testCase)
+            %% Setup object and sequence for slice-selective excitation test
+            [dt, ~, B1, grad, pos, delta, T1, T2, dB0, B1map, M0] = sssetup();
+            T1 = 600*T1; T2 = 100*T2;
+            dB0 = reshape(linspace(0, 100, length(dB0)), size(dB0));
+
+            % Symmetric splitting simulation
+            [Msim, ~] = bloch_symmetric_splitting(dt*1e-3, B1*1e-3, grad*1e-3, pos*1e-3, T1*1e-3, T2*1e-3, delta=delta, B0map=dB0*1e-6, B1map=B1map, Meq=M0);
+
+            figure();
+            [meas, Mz] = split_magnetization(Msim);
+            plot_magnetization(pos(3,:),meas,Mz);
+            sgtitle('SS B0 test simulation'); xlabel('Z-position (mm)')
+
+            % Compute and apply operator
+            [A, b] = event_operator(dt*1e-3, B1*1e-3, grad*1e-3, 'pos', pos*1e-3, 'T1', T1*1e-3, 'T2', T2*1e-3, 'B0map', dB0*1e-6, 'delta', delta, 'B1map', B1map);
+            Mop = pagemtimes(A, [zeros(size(T1)); zeros(size(T1)); M0]) + b;
+
+            % Compare
+            testCase.verifyLessThan(mean( (Msim(:) - Mop(:)).^2 ), 1e-6);
+        end
+
+        function ssB1mapTest(testCase)
+            %% Setup object and sequence for slice-selective excitation test
+            [dt, ~, B1, grad, pos, delta, T1, T2, dB0, B1map, M0] = sssetup();
+            T1 = 600*T1; T2 = 100*T2;
+            B1map = B1map.*reshape(linspace(0, 2, length(B1map)), size(B1map));
+
+            % Symmetric splitting simulation
+            [Msim, ~] = bloch_symmetric_splitting(dt*1e-3, B1*1e-3, grad*1e-3, pos*1e-3, T1*1e-3, T2*1e-3, delta=delta, B0map=dB0*1e-6, B1map=B1map, Meq=M0);
+
+            figure();
+            [meas, Mz] = split_magnetization(Msim);
+            plot_magnetization(pos(3,:),meas,Mz);
+            sgtitle('SS B1 map test simulation'); xlabel('Z-position (mm)')
+
+            % Compute and apply operator
+            [A, b] = event_operator(dt*1e-3, B1*1e-3, grad*1e-3, 'pos', pos*1e-3, 'T1', T1*1e-3, 'T2', T2*1e-3, 'B0map', dB0*1e-6, 'delta', delta, 'B1map', B1map);
+            Mop = pagemtimes(A, [zeros(size(T1)); zeros(size(T1)); M0]) + b;
+
+            % Compare
+            testCase.verifyLessThan(mean( (Msim(:) - Mop(:)).^2 ), 1e-6);
+        end
+
+        function ssM0Test(testCase)
+            %% Setup object and sequence for slice-selective excitation test
+            [dt, ~, B1, grad, pos, delta, T1, T2, dB0, B1map, M0] = sssetup();
+            T1 = 600*T1; T2 = 100*T2;
+            M0 = reshape(linspace(0.5, 1.5, length(M0)), size(M0));
+
+            % Symmetric splitting simulation
+            [Msim, ~] = bloch_symmetric_splitting(dt*1e-3, B1*1e-3, grad*1e-3, pos*1e-3, T1*1e-3, T2*1e-3, delta=delta, B0map=dB0*1e-6, B1map=B1map, Meq=M0);
+
+            figure();
+            [meas, Mz] = split_magnetization(Msim);
+            plot_magnetization(pos(3,:),meas,Mz);
+            sgtitle('SS M0 test simulation'); xlabel('Z-position (mm)')
+
+            % Compute and apply operator
+            [A, b] = event_operator(dt*1e-3, B1*1e-3, grad*1e-3, 'pos', pos*1e-3, 'T1', T1*1e-3, 'T2', T2*1e-3, 'B0map', dB0*1e-6, 'delta', delta, 'B1map', B1map);
+            Mop = pagemtimes(A, [zeros(size(T1)); zeros(size(T1)); M0]) + b;
+
+            % Compare
+            testCase.verifyLessThan(mean( (Msim(:) - Mop(:)).^2 ), 1e-6);
+        end
+
+        function ssB0Test(testCase)
+            %% Setup object and sequence for slice-selective excitation test
+            [dt, ~, B1, grad, pos, delta, T1, T2, dB0, B1map, M0] = sssetup();
+            T1 = 600*T1; T2 = 100*T2;
+
+            % Symmetric splitting simulation
+            [Msim, ~] = bloch_symmetric_splitting(dt*1e-3, B1*1e-3, grad*1e-3, pos*1e-3, T1*1e-3, T2*1e-3, delta=delta, B0map=dB0*1e-6, B1map=B1map, Meq=M0, B0=2.9);
+
+            figure();
+            [meas, Mz] = split_magnetization(Msim);
+            plot_magnetization(pos(3,:),meas,Mz);
+            sgtitle('SS B0 test simulation'); xlabel('Z-position (mm)')
+
+            % Compute and apply operator
+            [A, b] = event_operator(dt*1e-3, B1*1e-3, grad*1e-3, 'pos', pos*1e-3, 'T1', T1*1e-3, 'T2', T2*1e-3, 'B0map', dB0*1e-6, 'delta', delta, 'B1map', B1map, 'B0', 2.9);
+            Mop = pagemtimes(A, [zeros(size(T1)); zeros(size(T1)); M0]) + b;
+
+            % Compare
+            testCase.verifyLessThan(mean( (Msim(:) - Mop(:)).^2 ), 1e-6);
+        end
+
+        function ssGammaTest(testCase)
+            %% Setup object and sequence for slice-selective excitation test
+            [dt, ~, B1, grad, pos, delta, T1, T2, dB0, B1map, M0] = sssetup();
+            T1 = 600*T1; T2 = 100*T2;
+
+            % Symmetric splitting simulation
+            [Msim, ~] = bloch_symmetric_splitting(dt*1e-3, B1*1e-3, grad*1e-3, pos*1e-3, T1*1e-3, T2*1e-3, delta=delta, B0map=dB0*1e-6, B1map=B1map, Meq=M0, gamma=200e6);
+
+            figure();
+            [meas, Mz] = split_magnetization(Msim);
+            plot_magnetization(pos(3,:),meas,Mz);
+            sgtitle('SS gamma test simulation'); xlabel('Z-position (mm)')
+
+            % Compute and apply operator
+            [A, b] = event_operator(dt*1e-3, B1*1e-3, grad*1e-3, 'pos', pos*1e-3, 'T1', T1*1e-3, 'T2', T2*1e-3, 'B0map', dB0*1e-6, 'delta', delta, 'B1map', B1map, 'gamma', 200e6);
+            Mop = pagemtimes(A, [zeros(size(T1)); zeros(size(T1)); M0]) + b;
+
+            % Compare
+            testCase.verifyLessThan(mean( (Msim(:) - Mop(:)).^2 ), 1e-6);
+        end
+    end
+
+end
+
+function [dt, t, B1, grad, pos, delta, T1, T2, dB0, B1map, M0] = sssetup(Gz, dz, FA, T, dt)
+arguments
+    Gz = 30; % mT/m
+    dz = 5; % mm
+    FA = 90; % deg
+    T = 2; % ms
+    dt = 1e-3; % ms
+end
+%% Construct pulse sequence
+% RF field, mT
+[B1, t] = b1_sliceselect(Gz, dz, FA, T, dt);
+% Gradient, mT/m
+grad = gradient_trap(30, 0.150, T-0.150, 0.150, dt)';
+
+% Add rephasing gradient
+tmp = gradient_trap(-30, 0.150, 0.95, 0.15, dt)';
+B1 = [B1, zeros(size(tmp))];
+grad = [grad, tmp];
+t = [t, ( T + (0:(length(tmp)-1))*dt )];
+
+% Make other gradient directions zero magnitude
+grad = [zeros(2, length(grad)); grad];
+
+% Construct phantom and assign properties
+
+% Position, mm
+z = permute(-5:0.1:5, [1, 3, 2]);
+pos = [zeros(size(z)); zeros(size(z)); z];
+% Chemical shift, ppm
+delta = zeros(size(z));
+% Single-compartment T1 relaxation time, ms
+T1 = ones(size(z));
+% Single-compartment T2 relaxation time, ms
+T2 = ones(size(z));
+% B0 drift / variation
+dB0 = zeros(size(z));
+% B1 map
+B1map = ones(size(z));
+% Equilibrium magnetization
+M0 = ones(size(z));
+
+end

--- a/Testing/convergence_test_pwySplitting.m
+++ b/Testing/convergence_test_pwySplitting.m
@@ -14,7 +14,6 @@
 [file, pth] = uiputfile('*.mat', 'Select a location to save test files', 'mpme_fixedT1.mat');
 savePath = fullfile(pth, file(1:end-4));
 
-% Note that each one takes 30-40 minutes on a fast computer
 Nxs = [16, 32, 64, 128];
 
 seq = PulseSequence(PulseSequence.rf_specs(0, {'hard'}, 15, 320, 0), ...
@@ -119,19 +118,19 @@ for xidx = 1:length(Nxs)
     file = load(sprintf("%s_Nx=%d_compiled.mat", savePath, Nx));
 
     for pwyIdx = 1:4
-        figure(pwyIdx)
+        figure(pwyIdx + 1)
         plot(file.FAs, abs(file.im(1, :, pwyIdx, ech))); hold on
     end
     leg = [leg, sprintf("Nx=%d", Nx)];
 end
 
-figure(1); title('|F_{+1}|')
-figure(2); title('|F_{0}|')
-figure(3); title('|F_{-1}|')
-figure(4); title('|F_{-2}|')
+figure(2); title('|F_{+1}|')
+figure(3); title('|F_{0}|')
+figure(4); title('|F_{-1}|')
+figure(5); title('|F_{-2}|')
 
 for pwyIdx = 1:4
-    figure(pwyIdx);
+    figure(pwyIdx + 1);
     xlabel('FA (\circ)'); ylabel('Signal')
     grid on; hold off
     legend(leg, 'Location','southeast')


### PR DESCRIPTION
* Accelerate simulation with composed operators

Write event_operator function that creates a single linear operators as a composition of all the linear operators during that event.

Update simulate_acquisition code to use these operators to accelerate simulation.

* Debug

Corrected the implementation
Confirmed functionality with pathway splitting convergence test

* Sampling operators

Updated to compute operators for sampled events, as well. simulate_acquisition now makes full use of precomputed operators. Confirmed that it runs using convergence_test_pwySplitting Added documentation

* Implement testing

Implemented testing for event_operator, confirmed that results match for slice-select sequence with various changes to phantom/environment.